### PR TITLE
Add support for multiple teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These scripts read specific values from the bash environment. Be sure to set the
 ```bash
 export BOT_API_TOKEN="xoxb-asdfasdfasfasdfasdfsd" # The API Token for your bot, provided by Slack
 export itc_username="email@email.com" # The email you use to log into iTunes Connect
+export itc_team_id=77416800 #specify itunes team id if user has an access to multiple ones
 export bundle_id="com.best.app" # The bundle ID of the app you want these scripts to check
 ```
 

--- a/get-app-status.rb
+++ b/get-app-status.rb
@@ -35,6 +35,7 @@ end
 # Constants
 itc_username = ENV['itc_username']
 itc_password = ENV['itc_password']
+itc_team_id = ENV['itc_team_id']
 bundle_id = ENV['bundle_id']
 
 if (!itc_username)
@@ -48,6 +49,9 @@ else
  Spaceship::Tunes.login(itc_username)
 end
 
+if (itc_team_id)
+	Spaceship::Tunes.client.team_id = itc_team_id
+end
 # all json data
 versions = [] 
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/erikvillegas/itunes-connect-slack#readme",
   "dependencies": {
-    "@slack/client": "^3.16.0",
+    "@slack/client": "3.16.0",
     "dirty": "^1.1.0",
     "moment": "^2.24.0"
   }


### PR DESCRIPTION
As for know Spaceship::Tunes::Application.all returns empty array when user belongs to multiple teams. I was expecting the Spaceship to get the value from itc_team_id env when it's set up however it does not work. So here's my change which pass this env variable to the Spaceship which results in returning correct list of the results.

I also locked slack/webclient version to 3.16 as current implementation crashes with the latest one. Ideally code be updated to support the latest release but went with the quickest option

Hope that you'll like it and thanks for the great tool!