### PR TITLE
Fix bug in teams branch

### DIFF
--- a/get-app-status.rb
+++ b/get-app-status.rb
@@ -74,7 +74,7 @@ versions = []
 #add for the team_ids
 #test if itc_team doesnt exists
 
-if(itc_team_id_array)
+unless(itc_team_id_array.length.zero?)
 	for itc_team_id in itc_team_id_array
 		if (itc_team_id)
 			Spaceship::Tunes.client.team_id = itc_team_id


### PR DESCRIPTION
Return of ENV['itc_team_id'].to_s.split(",") is an array. 

It's always true in "if" statement, even array is empty.